### PR TITLE
Update ordinary-town.md

### DIFF
--- a/roles/ordinary-town.md
+++ b/roles/ordinary-town.md
@@ -11,11 +11,7 @@ The ordinary town, also known as vanilla townie, is part of the uninformed major
 
 There is a majority of town-aligned roles in each game and an ordinary town does not know the other town members, hence the uninformed majority.
 
-If you can't see any roles in the special-role-private-channel folder in the Mathia server you are an ordinary town. If you have questions about the game, check firsthand this Mathia rulebook but if you can't find your answer there send a direct message to the game masters on discord. 
+If you can't see any roles in the `special-role-private-channel` folder in the Mathia server you are an ordinary town. If you have questions about the game, check firsthand this Mathia rulebook but if you can't find your answer there send a direct message to the `@Game Masters` on Discord. 
 
-{% capture interactions %}
-
-An ordinary town does not have any interactions
-
-{% endcapture %}
-{% include interactions.html content=interactions %}
+### Interactions
+The Ordinary Town members do not have any special interactions.

--- a/roles/ordinary-town.md
+++ b/roles/ordinary-town.md
@@ -7,6 +7,15 @@ description: the uninformed majority
 special: ordinary
 ---
 
-Description of the role goes here.
+The ordinary town, also known as vanilla townie, is part of the uninformed majority and has no special abilities. In order to win, the townsfolk must find out who the mafias are and lynch them so that no mafias are left.
 
-Check out [Contributing]({{ site.baseurl }}{% link information/contributing.md %}) to see how to fill in this role!
+There is a majority of town-aligned roles in each game and an ordinary town does not know the other town members, hence the uninformed majority.
+
+If you can't see any roles in the special-role-private-channel folder in the Mathia server you are an ordinary town. If you have questions about the game, check firsthand this Mathia rulebook but if you can't find your answer there send a direct message to the game masters on discord. 
+
+{% capture interactions %}
+
+An ordinary town does not have any interactions
+
+{% endcapture %}
+{% include interactions.html content=interactions %}


### PR DESCRIPTION
I specified that if you are town you won't see any channels in the special-role-private-channels folder. I also wrote that if someone would happen to be unsure of their role they should contact the game masters. But I don't know if that is unnecessary or if it should be stated in general rules or something instead. Also, do you think it should be written somewhere in the rules that unless a player is sure how to play the game it is recommended to spectate first game? I didn't my first game and i think that it's good that it is not a rule that you have to spectate first round. But especially with these new rules it might not be needed, as long as new players have read through the rules carefully. What do you think? Sorry for the long message :(