### PR TITLE
Create Mason.md

### DIFF
--- a/roles/Mason.md
+++ b/roles/Mason.md
@@ -1,0 +1,18 @@
+---
+title: Mason
+layout: role         
+alignment: town
+enabled: no
+description: Two town-aligned players that know each other
+---
+
+At the beginning of each game two members of the town are placed in the same special role private channel called masons'-playhouse. The masons are two town members who have no special ability except knowing that the other is town.
+
+The masons are allowed to 'out' themselves as masons and request PRs (power roles) to claim their roles to them. If no no cc (counter claims) appear this is also most often the case. With whispers (using the shhhhhhh bot) enabled this allows a strong PR network, something that is generally considered OP (overpowered) which is why the masons are not in use anymore.
+
+{% capture interactions %}
+
+The masons do not have any interactions.
+
+{% endcapture %}
+{% include interactions.html content=interactions %}

--- a/roles/Mason.md
+++ b/roles/Mason.md
@@ -10,9 +10,5 @@ At the beginning of each game two members of the town are placed in the same spe
 
 The masons are allowed to 'out' themselves as masons and request PRs (power roles) to claim their roles to them. If no no cc (counter claims) appear this is also most often the case. With whispers (using the shhhhhhh bot) enabled this allows a strong PR network, something that is generally considered OP (overpowered) which is why the masons are not in use anymore.
 
-{% capture interactions %}
-
-The masons do not have any interactions.
-
-{% endcapture %}
-{% include interactions.html content=interactions %}
+### Interactions
+The <Role> does not have any special interactions.


### PR DESCRIPTION
I have a very important question (ok maybe not that important but anyways) - Should we write which channel each role is in? Right now, some channels are rather self-explanatory while others can be less obvious. If one happens to be in a channel where the name is not self-explanatory it will say that one is a certain role so idk. Some channel names were going to change as well? I like some funny names tho, so please don't change everything :) Also, when the masons first were introduced it was an idea that they were not allowed to out themselves but since they have been allowed to out themselves the last rounds when they were enabled I wrote that it was allowed. Anyway, masons are probably not going to come into play again so it doesn't really matter.