### PR TITLE
Update Mason.md

### DIFF
--- a/roles/Mason.md
+++ b/roles/Mason.md
@@ -6,9 +6,7 @@ enabled: no
 description: Two town-aligned players that know each other
 ---
 
-At the beginning of each game two members of the town are placed in the same special role private channel called masons'-playhouse. The masons are two town members who have no special ability except knowing that the other is town.
-
-The masons are allowed to 'out' themselves as masons and request PRs (power roles) to claim their roles to them. If no no cc (counter claims) appear this is also most often the case. With whispers (using the shhhhhhh bot) enabled this allows a strong PR network, something that is generally considered OP (overpowered) which is why the masons are not in use anymore.
+At the beginning of each game two members of the town are placed in the same special role private channel called masons'-playhouse. The masons are two town members who have no special ability except knowing that the other is town. The masons are allowed to publicly claim masons.
 
 ### Interactions
-The <Role> does not have any special interactions.
+The Masons don't have any night actions.


### PR DESCRIPTION
I read what people wrote in the server and agree that there should be no tips in role descriptions. However, I decided to keep that masons are allowed to claim in public channels since that was not evident when the role was introduced. If someone doesn't agree on this, they can, of course, change it :)